### PR TITLE
Add Windows build steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ From the root folder of the project:
 
     sudo ./build.sh
  
+Or as a Windows user, run the following and follow the end-stage instruction:
+
+    build.bat
+
 You can now access the script from anywhere through the command `isc`. 
 
 ## Updating

--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,27 @@
+@echo off
+
+REM Start by building the PHP script
+php build.php
+
+REM Set up the Dekode directory if it does not already exist
+if not exist "%appdata%\Dekode\InsightlyCLI\NUL" mkdir "%appdata%\Dekode\InsightlyCLI"
+
+REM Copy the insightly cli file to the newly created directory
+SET COPYCMD=\Y && move insightly-cli.phar "%appdata%\Dekode\InsightlyCLI\insightly-cli.phar"
+
+REM Delete the batch file if it exists, in case updates were made
+if exist "%appdata%\Dekode\InsightlyCLI\isc.bat" del "%appdata%\Dekode\InsightlyCLI\isc.bat"
+
+REM Write the isc.bat file to actually run the commands through
+@echo @echo OFF > "%appdata%\Dekode\InsightlyCLI\isc.bat"
+@echo :: in case DelayedExpansion is on and a path contains ! > "%appdata%\Dekode\InsightlyCLI\isc.bat"
+@echo setlocal DISABLEDELAYEDEXPANSION > "%appdata%\Dekode\InsightlyCLI\isc.bat"
+@echo php "%appdata%\Dekode\InsightlyCLI\insightly-cli.phar" %%* > "%appdata%\Dekode\InsightlyCLI\isc.bat"
+
+
+REM Check if system variables have previously been setm if not add our new path
+echo %path% | find "Dekode\InsightlyCLI" > nul
+if errorlevel 1 (echo Add "%appdata%\Dekode\InsightlyCLI\" to your system path)
+
+REM Delete the compressed version of the file not being used
+del insightly-cli.phar.gz /f /q


### PR DESCRIPTION
This just creates a `build.bat` file to compliment the `build.sh` file that already exists.

The Windows-oriented file allows us poor Windows souls to quickly build the project, get it placed in a reasonable location, and have an easy way to update in the future as well.

The only caveat is that there's a manual step, which is printed to your screen upon completion, where the user needs to add the file to their system path (a windows user wanting ot use command line would know how to do this, and the value that needs ot be added is provided for you as well).

The script is now available through `isc` in powershell or plain command line applets on Windows, hooray!